### PR TITLE
Align keypad quit behavior with documentation and conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ You can customize Evil Keypad via `M-x customize-group RET evil-keypad RET`. Her
 | `evil-keypad-C-h-trigger`                | `h`     | First key to represent the `C-h` prefix                             |
 | `evil-keypad-universal-argument-trigger` | `u`     | Key to emulate universal argument (`C-u`)                           |
 | `evil-keypad-negative-argument-trigger`  | `-`     | Key to emulate negative argument (`M--`)                            |
+| `evil-keypad-quit-key`                   | `ESC`   | Key to quit the keypad                                              |
 
 ## License
 

--- a/evil-keypad.el
+++ b/evil-keypad.el
@@ -143,7 +143,7 @@ Used after first key is entered."
   :type 'character :group 'evil-keypad)
 
 ;;;###autoload
-(defcustom evil-keypad-quit-key (kbd "C-g")
+(defcustom evil-keypad-quit-key (kbd "ESC")
   "Key to quit the keypad input state."
   :type 'string :group 'evil-keypad)
 
@@ -418,6 +418,7 @@ Returns t to exit."
   "Create and return the keypad state keymap."
   (let ((map (make-sparse-keymap)))
     (define-key map evil-keypad-quit-key #'evil-keypad-quit)
+    (define-key map (kbd "C-g") #'evil-keypad-quit)
     (define-key map (kbd "<backspace>") #'evil-keypad-undo)
     (define-key map (kbd "DEL") #'evil-keypad-undo)
     map))


### PR DESCRIPTION
This pull request addresses a discrepancy between the documented behavior and the current implementation.

* The README.md states that `ESC` should quit the keypad state. This functionality was removed in commit [evil-keypad: add customizable quit key and refactor keymap initialization](https://github.com/achyudh/evil-keypad/commit/f49cb8c4488d5cdac42bf927a4a8b0e556fb72ec).
* This change restores `ESC` as the default value for the `evil-keypad-quit-key` customization variable, aligning the behavior with the documentation.
* Additionally, `C-g` is now bound to always quit the keypad, providing a more intuitive and expected user experience.